### PR TITLE
Replace SVGO with svgmin

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,7 +36,7 @@ var changeEvent = function(evt) {
 gulp.task('svgSprite', function () {
 
 	return gulp.src(paths.sprite.src)
-		.pipe(plugins.svgo())
+		.pipe(plugins.svgmin())
 		.pipe(plugins.svgSprite({
 			"mode": {
 				"css": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "gulp-load-plugins": "^0.4.0",
     "gulp-svg-sprite": "^1.0.19",
     "gulp-svg2png": "^0.3.0",
-    "gulp-svgo": "^0.1.1",
+    "gulp-svgmin": "^1.2.0",
     "gulp-util": "^2.2.14",
     "vinyl": "^0.4.6"
   }


### PR DESCRIPTION
The SVGO Gulp package no longer exists, and the SVGO plugin suggests to
use gulp-svgmin https://github.com/svg/svgo
